### PR TITLE
Add pre-commit hook for branch name validation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+LC_ALL=C
+
+local_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+valid_branch_regex="^(dependabot|feature|fix|docs|style|refactor|perf|hotfix|test|chore|create)(\/[a-zA-Z0-9._-]+)+$"
+
+message="There is something wrong with your branch name. Branch names in this project must adhere to this contract: $valid_branch_regex. Your commit will be rejected. You should rename your branch to a valid name and try again."
+
+if [[ ! $local_branch =~ $valid_branch_regex ]]
+then
+    echo "$message"
+    exit 1
+fi


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [ ] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->


___

### **Description**
- Introduced a pre-commit hook to enforce branch naming conventions.
- The hook checks if the current branch name matches a specified regex pattern.
- If the branch name is invalid, it rejects the commit with an informative message.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-commit</strong><dd><code>Implement pre-commit hook for branch name validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.githooks/pre-commit
<li>Added a pre-commit hook script.<br> <li> Validates branch names against a regex pattern.<br> <li> Provides error message for invalid branch names.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-workflows/pull/6/files#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcb">+14/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

