### PR TITLE
Update csharpier.yml - Set default repository name

### DIFF
--- a/.github/workflows/csharpier.yml
+++ b/.github/workflows/csharpier.yml
@@ -10,7 +10,7 @@ on:
       repository:
         description: "The repository to run"
         required: true
-        default: "gstraccini-bot"
+        default: "gstraccini-bot-workflows"
       branch:
         description: "The branch to run"
         required: true


### PR DESCRIPTION
## 📑 Description
Update csharpier.yml - Set default repository name

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

CI:
- Update the CSharpier workflow configuration to use "gstraccini-bot-workflows" as the default repository name.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the default repository name in `csharpier.yml` from "gstraccini-bot" to "gstraccini-bot-workflows".

### Why are these changes being made?

The change is made to align the repository name with its intended purpose or structure, likely reflecting a reorganization or clarification in naming to better match the project setup. This helps prevent confusion by ensuring automation runs against the correct repository defaults.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->