### PR TITLE
Update csharpier.yml

### DIFF
--- a/.github/workflows/csharpier.yml
+++ b/.github/workflows/csharpier.yml
@@ -47,6 +47,7 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repository }}
           check_id: ${{ github.event.inputs.checkRunId }}
           status: in_progress
           details_url: ${{ env.GHA_URL }}
@@ -156,6 +157,7 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repository }}
           check_id: ${{ github.event.inputs.checkRunId }}
           conclusion: success
           details_url: ${{ env.GHA_URL }}
@@ -180,6 +182,7 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repository }}
           check_id: ${{ github.event.inputs.checkRunId }}
           conclusion: failure
           details_url: ${{ env.GHA_URL }}


### PR DESCRIPTION
### **User description**
## 📑 Description
repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repository }}

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Added `repo` parameter to the `checks-action` steps to provide repository context.
- This change improves the workflow's ability to reference the correct repository dynamically.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>csharpier.yml</strong><dd><code>Enhance csharpier workflow with repository context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/csharpier.yml
<li>Added <code>repo</code> parameter to multiple steps.<br> <li> Enhanced the configuration for better repository context.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-workflows/pull/92/files#diff-f8e312298ad7948125fad1d08ed589674c21b7a427f5e30cf33fb63e2c528dab">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to ensure check runs are correctly associated with the specified repository during workflow dispatch events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->