### PR TITLE
feat: add autofix feature to centralised package converter

### DIFF
--- a/.github/workflows/dotnet-centralised-package-converter.yml
+++ b/.github/workflows/dotnet-centralised-package-converter.yml
@@ -21,6 +21,10 @@ on:
       checkRunId:
         description: "Check run ID"
         required: true
+      autofix:
+        description: "Attempt to automatically fix NU1010/NU1008 errors by adding missing PackageVersion entries and removing duplicate Version attributes"
+        required: false
+        default: "false"
 
 env:
   GHA_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -84,7 +88,70 @@ jobs:
 
       - name: Run central-pkg-converter
         run: |
-          NO_COLOR=1 central-pkg-converter -f -t "$SLN_FILE" 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[a-zA-Z0-9/]*\]//g' >> central-pkg-converter.log
+          NO_COLOR=1 central-pkg-converter -f -t "./" 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[a-zA-Z0-9/]*\]//g' >> central-pkg-converter.log
+
+      - name: Autofix missing PackageVersion entries
+        if: ${{ github.event.inputs.autofix == 'true' }}
+        run: |
+          printf "\n--- Autofix ---\n" >> central-pkg-converter.log
+          cat > /tmp/cpm_autofix.py << 'AUTOFIX'
+          import re, os, glob
+
+          props_file = "Directory.Packages.props"
+
+          if not os.path.exists(props_file):
+              print("No Directory.Packages.props found, skipping autofix.")
+              exit(0)
+
+          props_content = open(props_file).read()
+
+          # Packages already declared in Directory.Packages.props
+          existing = set(re.findall(r'<PackageVersion\s+Include="([^"]+)"', props_content))
+
+          # Collect packages with explicit versions from csproj files not yet in props (NU1010 fix)
+          to_add = {}
+          for csproj in sorted(glob.glob("**/*.csproj", recursive=True)):
+              content = open(csproj).read()
+              for m in re.finditer(r'<PackageReference\s+Include="([^"]+)"(?:[^>]*?)Version="([^"]+)"', content, re.DOTALL):
+                  pkg, ver = m.group(1), m.group(2).strip()
+                  if ver and ver != "." and pkg not in existing and pkg not in to_add:
+                      to_add[pkg] = ver
+
+          if to_add:
+              entries = "\n".join(f'    <PackageVersion Include="{p}" Version="{v}" />' for p, v in sorted(to_add.items()))
+              insert_at = props_content.rfind("</ItemGroup>")
+              if insert_at == -1:
+                  props_content = props_content.replace("</Project>", f"  <ItemGroup>\n{entries}\n  </ItemGroup>\n</Project>")
+              else:
+                  props_content = props_content[:insert_at] + entries + "\n  " + props_content[insert_at:]
+              open(props_file, "w").write(props_content)
+              print(f"Added {len(to_add)} missing PackageVersion entries to {props_file}:")
+              for p, v in sorted(to_add.items()):
+                  print(f"  {p} {v}")
+          else:
+              print(f"No missing PackageVersion entries with resolvable versions found.")
+
+          # NU1008 fix: remove Version from PackageReference where PackageVersion now exists
+          all_versioned = set(re.findall(r'<PackageVersion\s+Include="([^"]+)"', props_content))
+          fixed_files = []
+          for csproj in sorted(glob.glob("**/*.csproj", recursive=True)):
+              content = open(csproj).read()
+              new_content = content
+              for pkg in all_versioned:
+                  new_content = re.sub(
+                      r'(<PackageReference\s+Include="' + re.escape(pkg) + r'"[^>]*?)\s+Version="[^"]*"',
+                      r"\1", new_content, flags=re.DOTALL)
+              if new_content != content:
+                  open(csproj, "w").write(new_content)
+                  fixed_files.append(csproj)
+
+          if fixed_files:
+              print(f"\nRemoved stale Version attribute from {len(fixed_files)} project file(s) (NU1008 fix):")
+              for f in fixed_files:
+                  print(f"  {f}")
+          AUTOFIX
+          python3 /tmp/cpm_autofix.py >> central-pkg-converter.log 2>&1
+          rm -f /tmp/cpm_autofix.py
 
       - name: Validate conversion
         id: validate

--- a/.github/workflows/infisical-secrets-check.yml
+++ b/.github/workflows/infisical-secrets-check.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-permissions: read-all
-
 jobs:
   secrets-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📑 Description
Introduce an optional 'autofix' input parameter to the dotnet- centralised-package-converter workflow for automatic resolution of NU1010/NU1008 errors. This functionality attempts to add missing PackageVersion entries in Directory.Packages.props, and removes duplicate Version attributes in .csproj files.

Additionally, update the directory target for the central-pkg- converter from solution file to root directory, enhancing processing flexibility and accuracy for diverse project structures. This change streamlines the conversion process and ensures package consistency without manual intervention.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add an optional autofix mode to the dotnet centralised package converter workflow and adjust its target scope while tidying CI workflow permissions.

New Features:
- Introduce an optional `autofix` input to the dotnet-centralised-package-converter workflow to automatically resolve NU1010/NU1008 errors by syncing `PackageVersion` entries and removing redundant `Version` attributes.

Enhancements:
- Update the centralised package converter to run against the repository root directory instead of a specific solution file for broader project coverage.

CI:
- Remove the explicit `permissions: read-all` declaration from the Infisical secrets check workflow to rely on default permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional auto-fix capability to automatically manage package version entries and clean up stale configuration settings.

* **Chores**
  * Updated CI/CD workflow configurations and improved security permissions handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/gstraccini-bot-workflows/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->